### PR TITLE
Update README.md -add Appimage decoder path

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,12 @@ cd ~/.local/share/libsigrokdecode/decoders/dshot
 Then clone this repository
 
 Reload sigrok-cli/pulseview
+
+## linux PulseView AppImage
+sudo mkdir -p /__w/sigrok-build/sigrok-build/sr/share/libsigrokdecode/decoders
+
+cd /__w/sigrok-build/sigrok-build/sr/share/libsigrokdecode/decoders
+
+use sudo to clone this repository
+
+Reload sigrok-cli/pulseview


### PR DESCRIPTION
I don't like using sudo but this was the only way I found to allow the decoder to persist across PulseView AppImage sessions.